### PR TITLE
use 2to3 to translate code to python3

### DIFF
--- a/examdownloader-cli.py
+++ b/examdownloader-cli.py
@@ -21,7 +21,7 @@ def startDownload(args):
 
 
     def updateStatus(msg, type='normal'):
-        print msg
+        print(msg)
 
     def downloadCallback(status, lastfile='', numFiles=0):
         if status:

--- a/examdownloader-gui.py
+++ b/examdownloader-gui.py
@@ -1,7 +1,7 @@
-from Tkinter import *
-import tkFileDialog
+from tkinter import *
+import tkinter.filedialog
 import subprocess
-import thread
+import _thread
 import examdownloader
 
 FONT = ('Arial', 14, 'bold')
@@ -66,7 +66,7 @@ class examdownloadergui(object):
         root.mainloop()
 
     def askForDestination(self):
-        self.destination = tkFileDialog.askdirectory(mustexist=False, parent=self.top, title='Choose a destination')
+        self.destination = tkinter.filedialog.askdirectory(mustexist=False, parent=self.top, title='Choose a destination')
         self.destField.delete(0, END)
         self.destField.insert(0, self.destination)
 
@@ -84,7 +84,7 @@ class examdownloadergui(object):
             else:
                 self.updateStatus('Paper not released by Department', 'error')
 
-        thread.start_new_thread(ed.getContents, (module, username, password, destination, downloadCallback, self.updateStatus))
+        _thread.start_new_thread(ed.getContents, (module, username, password, destination, downloadCallback, self.updateStatus))
 
     def updateStatus(self, msg, type='normal'):
         self.statusLabel['text'] = msg

--- a/examdownloader.py
+++ b/examdownloader.py
@@ -1,5 +1,5 @@
-import httplib
-import urllib
+import http.client
+import urllib.request, urllib.parse, urllib.error
 import os
 
 class examdownloader(object):
@@ -9,7 +9,7 @@ class examdownloader(object):
     def getContents(self, module, username, password, destination, downloadEndCallback, updateStatus):
         updateStatus('Connecting to NUS Library Portals...')
 
-        conn = httplib.HTTPSConnection('libbrs.nus.edu.sg')
+        conn = http.client.HTTPSConnection('libbrs.nus.edu.sg')
         page = '/infogate/loginAction.do?execution=login'
         conn.request('GET', page)
 
@@ -32,9 +32,9 @@ class examdownloader(object):
             'domain': 'NUSSTU',
             'key': 'blankid+RESULT+EXAM+' + module
         }
-        params = urllib.urlencode(params)
+        params = urllib.parse.urlencode(params)
 
-        conn = httplib.HTTPSConnection('libbrs.nus.edu.sg')
+        conn = http.client.HTTPSConnection('libbrs.nus.edu.sg')
         conn.request('POST', page, params, headers)
         resp = conn.getresponse()
         data = str(resp.read())
@@ -44,12 +44,12 @@ class examdownloader(object):
             updateStatus("Wrong username/password", "error")
             return
 
-        conn = httplib.HTTPSConnection('libbrs.nus.edu.sg')
+        conn = http.client.HTTPSConnection('libbrs.nus.edu.sg')
         page = '/infogate/jsp/login/success.jsp;jsessionid='+sessionid+'?exe=ResultList'
         conn.request('GET', page, params, headersGet)
         conn.close()
 
-        conn = httplib.HTTPSConnection('libbrs.nus.edu.sg')
+        conn = http.client.HTTPSConnection('libbrs.nus.edu.sg')
         page = '/infogate/searchAction.do?execution=ResultList'
         params = 'database=EXAM&searchstring='+module+'&d='
         conn.request('POST', page, params, headers)
@@ -68,11 +68,11 @@ class examdownloader(object):
             return
 
         for i in range(1, maxDocIndex+1):
-            conn = httplib.HTTPSConnection('libbrs.nus.edu.sg')
+            conn = http.client.HTTPSConnection('libbrs.nus.edu.sg')
             page = '/infogate/searchAction.do?execution=ViewSelectedResultListLong'
             params['preSelectedId'] = i
             params['exportids'] = i
-            conn.request('POST', page, urllib.urlencode(params), headers)
+            conn.request('POST', page, urllib.parse.urlencode(params), headers)
             resp = conn.getresponse()
             data = resp.read()
             conn.close()
@@ -95,11 +95,11 @@ class examdownloader(object):
             pdfs[title] = page
 
         counter = 0;
-        for title, page in pdfs.items():
+        for title, page in list(pdfs.items()):
             counter += 1
             updateStatus('Downloading ' + str(counter) + ' of ' + str(len(pdfs)))
 
-            conn = httplib.HTTPSConnection('libbrs.nus.edu.sg')
+            conn = http.client.HTTPSConnection('libbrs.nus.edu.sg')
             conn.request('GET', page, None, headersGet)
             resp = conn.getresponse()
             data = resp.read()
@@ -112,10 +112,10 @@ class examdownloader(object):
                 os.makedirs(os.path.dirname(filename))
             try:
                 f = open(filename, 'wb')
-                print('Writing ' + title)
+                print(('Writing ' + title))
                 f.write(data)
                 f.close()
-            except Exception, e:
+            except Exception as e:
                 updateStatus('Invalid destination', 'error')
                 return
 


### PR DESCRIPTION
use 2to3 to translate code to python3.

exact command ran: `2to3 -w *.py`

also fixes #5 since my macOS python2 was too old to support TLS 1.2