### PR TITLE
Change default username to reflect actually needed username

### DIFF
--- a/examdownloader-cli.py
+++ b/examdownloader-cli.py
@@ -4,7 +4,7 @@ import getpass
 import examdownloader
 
 module = 'CS1010S'
-username = 'A0012345'
+username = 'E0123456'
 destination = './'
 
 def startDownload(args):


### PR DESCRIPTION
The username that needs to be inserted is actually "E..." instead of the matriculation number.
Hence I changed the default line to prevent confusion.