### PR TITLE
Improve input on examdownloader-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ Runs on Python 2.7 only.
 
 ### Using via Command Line
 ```
-$ python examdownloader-cli.py <MODULE CODE> <NUSNET ID>
+$ python examdownloader-cli.py
 ```
+
+The required username and target destination can be set in the script or passed as a command line argument.
+If no command line arguments are provided, the user is prompted for input.
 
 ### Using via a Graphical User Interface
 ```

--- a/examdownloader-cli.py
+++ b/examdownloader-cli.py
@@ -1,12 +1,10 @@
 import subprocess
-import sys
 import getpass
 import examdownloader
 import argparse
 
 # Insert configuration here
 username = ""       # NUSNET ID i.e. "E0123456"
-password = ""       # NUSNET password
 destination = ""    # target destination i.e. "." (current directory)
 
 
@@ -40,8 +38,7 @@ if __name__ == '__main__':
     if not username:
         username = raw_input('Enter NUSNET ID: ')
 
-    if not password:
-        password = getpass.getpass('Enter password for {}: '.format(username))
+    password = getpass.getpass('Enter password for {}: '.format(username))
 
     if not module:
         module = raw_input("Enter module to download exams for: ")

--- a/examdownloader-cli.py
+++ b/examdownloader-cli.py
@@ -32,20 +32,24 @@ if __name__ == '__main__':
     parser.add_argument('-m', '--module', help="Module of which to download exam papers", type=str)
     args = vars(parser.parse_args())
 
-    module = args.get("module")
+    # If not set by user in top part of the file
     if not username:
         username = args.get("user")
+    # If not set by user even in the command line arguments
     if not username:
         username = raw_input('Enter NUSNET ID: ')
 
+    # always ask for security reasons
     password = getpass.getpass('Enter password for {}: '.format(username))
 
+    # expected to be set newly with each call
+    module = args.get("module")
+    # if not set in CL arguments
     if not module:
         module = raw_input("Enter module to download exams for: ")
 
+    # If not set by user in top part of the file
     if not destination:
         destination = args.get("dest")
-    if not destination:
-        destination = raw_input('Enter location to store exams in: ')
 
     startDownload(module, username, destination, password)

--- a/examdownloader-cli.py
+++ b/examdownloader-cli.py
@@ -5,7 +5,7 @@ import argparse
 
 # Insert configuration here
 username = ""       # NUSNET ID i.e. "E0123456"
-destination = ""    # target destination i.e. "." (current directory)
+destination = "."    # target destination i.e. "." (current directory)
 
 
 def startDownload(module, username, destination, password):
@@ -28,7 +28,7 @@ def startDownload(module, username, destination, password):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Downloads exam papers from UCL automatically")
     parser.add_argument('-u', '--user', help="NUSNET ID", type=str)
-    parser.add_argument('-d', '--dest', help="Path to store files", type=str)
+    parser.add_argument('-d', '--dest', help="Path to store files", type=str, default=".")
     parser.add_argument('-m', '--module', help="Module of which to download exam papers", type=str)
     args = vars(parser.parse_args())
 

--- a/examdownloader-cli.py
+++ b/examdownloader-cli.py
@@ -26,7 +26,7 @@ def startDownload(module, username, destination, password):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Downloads exam papers from UCL automatically")
+    parser = argparse.ArgumentParser(description="Downloads exam papers from NUS Library Portal automatically")
     parser.add_argument('-u', '--user', help="NUSNET ID", type=str)
     parser.add_argument('-d', '--dest', help="Path to store files", type=str, default=".")
     parser.add_argument('-m', '--module', help="Module of which to download exam papers", type=str)

--- a/examdownloader-cli.py
+++ b/examdownloader-cli.py
@@ -2,23 +2,17 @@ import subprocess
 import sys
 import getpass
 import examdownloader
+import argparse
 
-module = 'CS1010S'
-username = 'A0012345'
-destination = './'
+# Insert configuration here
+username = ""       # NUSNET ID i.e. "E0123456"
+password = ""       # NUSNET password
+destination = ""    # target destination i.e. "." (current directory)
 
-def startDownload(args):
 
-    global module, username
-    password = ''
+def startDownload(module, username, destination, password):
 
-    if len(args) > 0:
-        module = args[0]
-        username = args[1]
-
-    password = getpass.getpass('Enter password for ' + username + ': ')
     ed = examdownloader.examdownloader('CLI')
-
 
     def updateStatus(msg, type='normal'):
         print msg
@@ -32,5 +26,29 @@ def startDownload(args):
 
     ed.getContents(module, username, password, destination, downloadCallback, updateStatus)
 
+
 if __name__ == '__main__':
-    startDownload(sys.argv[1:])
+    parser = argparse.ArgumentParser(description="Downloads exam papers from UCL automatically")
+    parser.add_argument('-u', '--user', help="NUSNET ID", type=str)
+    parser.add_argument('-d', '--dest', help="Path to store files", type=str)
+    parser.add_argument('-m', '--module', help="Module of which to download exam papers", type=str)
+    args = vars(parser.parse_args())
+
+    module = args.get("module")
+    if not username:
+        username = args.get("user")
+    if not username:
+        username = raw_input('Enter NUSNET ID: ')
+
+    if not password:
+        password = getpass.getpass('Enter password for {}: '.format(username))
+
+    if not module:
+        module = raw_input("Enter module to download exams for: ")
+
+    if not destination:
+        destination = args.get("dest")
+    if not destination:
+        destination = raw_input('Enter location to store exams in: ')
+
+    startDownload(module, username, destination, password)


### PR DESCRIPTION
Provides more comfortable user input options for the cli

- users can still manipulate the script to set default values
- users can pass cli arguments so as to not having to change the script
- if none of the above is done, the user is prompted for input on start

The above works independently for each argument (except for password which can only be prompted)