### PR TITLE
Remove erroneous and unnecessary subprocess call

### DIFF
--- a/examdownloader-cli.py
+++ b/examdownloader-cli.py
@@ -26,7 +26,6 @@ def startDownload(args):
     def downloadCallback(status, lastfile='', numFiles=0):
         if status:
             updateStatus(str(numFiles) + ' papers downloaded successfully!', 'success')
-            subprocess.call(['open', '-R', lastfile])
         else:
             updateStatus('Paper not released by Department', 'error')
 

--- a/examdownloader-cli.py
+++ b/examdownloader-cli.py
@@ -23,7 +23,7 @@ def startDownload(args):
     def updateStatus(msg, type='normal'):
         print msg
 
-    def downloadCallback(status, lastfile='', numFiles=0):
+    def downloadCallback(status, numFiles=0):
         if status:
             updateStatus(str(numFiles) + ' papers downloaded successfully!', 'success')
         else:

--- a/examdownloader-gui.py
+++ b/examdownloader-gui.py
@@ -77,7 +77,7 @@ class examdownloadergui(object):
         destination = self.destField.get()
         ed = examdownloader.examdownloader('GUI')
 
-        def downloadCallback(status, lastfile='', numFiles=0):
+        def downloadCallback(status, numFiles=0):
             if status:
                 self.updateStatus(str(numFiles) + ' papers downloaded successfully!', 'success')
             else:

--- a/examdownloader-gui.py
+++ b/examdownloader-gui.py
@@ -80,7 +80,6 @@ class examdownloadergui(object):
         def downloadCallback(status, lastfile='', numFiles=0):
             if status:
                 self.updateStatus(str(numFiles) + ' papers downloaded successfully!', 'success')
-                subprocess.call(['open', '-R', lastfile])
             else:
                 self.updateStatus('Paper not released by Department', 'error')
 

--- a/examdownloader.py
+++ b/examdownloader.py
@@ -120,7 +120,7 @@ class examdownloader(object):
                 return
 
         if 'filename' in vars():
-            downloadEndCallback(True, filename, counter)
+            downloadEndCallback(True, counter)
         else:
             downloadEndCallback(False)
 


### PR DESCRIPTION
At the end of downloading exams, "open -R last-file" is called.
This command is not supported on all operating systems and may be removed in my opinion.