### PR TITLE
Convert scripts from Python 2 to Python 3

### DIFF
--- a/examdownloader-cli.py
+++ b/examdownloader-cli.py
@@ -13,7 +13,7 @@ def startDownload(module, username, destination, password):
     ed = examdownloader.examdownloader('CLI')
 
     def updateStatus(msg, type='normal'):
-        print msg
+        print(msg)
 
     def downloadCallback(status, lastfile='', numFiles=0):
         if status:
@@ -37,7 +37,7 @@ if __name__ == '__main__':
         username = args.get("user")
     # If not set by user even in the command line arguments
     if not username:
-        username = raw_input('Enter NUSNET ID: ')
+        username = input('Enter NUSNET ID: ')
 
     # always ask for security reasons
     password = getpass.getpass('Enter password for {}: '.format(username))
@@ -46,7 +46,7 @@ if __name__ == '__main__':
     module = args.get("module")
     # if not set in CL arguments
     if not module:
-        module = raw_input("Enter module to download exams for: ")
+        module = input("Enter module to download exams for: ")
 
     # If not set by user in top part of the file
     # defaults to "." by configuration of argparse

--- a/examdownloader-gui.py
+++ b/examdownloader-gui.py
@@ -1,7 +1,7 @@
-from Tkinter import *
-import tkFileDialog
+from tkinter import *
+import tkinter.filedialog
 import subprocess
-import thread
+import _thread
 import examdownloader
 
 FONT = ('Arial', 14, 'bold')
@@ -66,7 +66,7 @@ class examdownloadergui(object):
         root.mainloop()
 
     def askForDestination(self):
-        self.destination = tkFileDialog.askdirectory(mustexist=False, parent=self.top, title='Choose a destination')
+        self.destination = tkinter.filedialog.askdirectory(mustexist=False, parent=self.top, title='Choose a destination')
         self.destField.delete(0, END)
         self.destField.insert(0, self.destination)
 
@@ -84,7 +84,7 @@ class examdownloadergui(object):
             else:
                 self.updateStatus('Paper not released by Department', 'error')
 
-        thread.start_new_thread(ed.getContents, (module, username, password, destination, downloadCallback, self.updateStatus))
+        _thread.start_new_thread(ed.getContents, (module, username, password, destination, downloadCallback, self.updateStatus))
 
     def updateStatus(self, msg, type='normal'):
         self.statusLabel['text'] = msg

--- a/examdownloader.py
+++ b/examdownloader.py
@@ -1,5 +1,5 @@
-import httplib
-import urllib
+import http.client
+import urllib.request, urllib.parse, urllib.error
 import os
 
 class examdownloader(object):
@@ -9,7 +9,7 @@ class examdownloader(object):
     def getContents(self, module, username, password, destination, downloadEndCallback, updateStatus):
         updateStatus('Connecting to NUS Library Portals...')
 
-        conn = httplib.HTTPSConnection('libbrs.nus.edu.sg')
+        conn = http.client.HTTPSConnection('libbrs.nus.edu.sg')
         page = '/infogate/loginAction.do?execution=login'
         conn.request('GET', page)
 
@@ -32,9 +32,9 @@ class examdownloader(object):
             'domain': 'NUSSTU',
             'key': 'blankid+RESULT+EXAM+' + module
         }
-        params = urllib.urlencode(params)
+        params = urllib.parse.urlencode(params)
 
-        conn = httplib.HTTPSConnection('libbrs.nus.edu.sg')
+        conn = http.client.HTTPSConnection('libbrs.nus.edu.sg')
         conn.request('POST', page, params, headers)
         resp = conn.getresponse()
         data = str(resp.read())
@@ -44,12 +44,12 @@ class examdownloader(object):
             updateStatus("Wrong username/password", "error")
             return
 
-        conn = httplib.HTTPSConnection('libbrs.nus.edu.sg')
+        conn = http.client.HTTPSConnection('libbrs.nus.edu.sg')
         page = '/infogate/jsp/login/success.jsp;jsessionid='+sessionid+'?exe=ResultList'
         conn.request('GET', page, params, headersGet)
         conn.close()
 
-        conn = httplib.HTTPSConnection('libbrs.nus.edu.sg')
+        conn = http.client.HTTPSConnection('libbrs.nus.edu.sg')
         page = '/infogate/searchAction.do?execution=ResultList'
         params = 'database=EXAM&searchstring='+module+'&d='
         conn.request('POST', page, params, headers)
@@ -68,11 +68,11 @@ class examdownloader(object):
             return
 
         for i in range(1, maxDocIndex+1):
-            conn = httplib.HTTPSConnection('libbrs.nus.edu.sg')
+            conn = http.client.HTTPSConnection('libbrs.nus.edu.sg')
             page = '/infogate/searchAction.do?execution=ViewSelectedResultListLong'
             params['preSelectedId'] = i
             params['exportids'] = i
-            conn.request('POST', page, urllib.urlencode(params), headers)
+            conn.request('POST', page, urllib.parse.urlencode(params), headers)
             resp = conn.getresponse()
             data = resp.read()
             conn.close()
@@ -95,11 +95,11 @@ class examdownloader(object):
             pdfs[title] = page
 
         counter = 0;
-        for title, page in pdfs.items():
+        for title, page in list(pdfs.items()):
             counter += 1
             updateStatus('Downloading ' + str(counter) + ' of ' + str(len(pdfs)))
 
-            conn = httplib.HTTPSConnection('libbrs.nus.edu.sg')
+            conn = http.client.HTTPSConnection('libbrs.nus.edu.sg')
             conn.request('GET', page, None, headersGet)
             resp = conn.getresponse()
             data = resp.read()
@@ -112,10 +112,10 @@ class examdownloader(object):
                 os.makedirs(os.path.dirname(filename))
             try:
                 f = open(filename, 'wb')
-                print('Writing ' + title)
+                print(('Writing ' + title))
                 f.write(data)
                 f.close()
-            except Exception, e:
+            except Exception as e:
                 updateStatus('Invalid destination', 'error')
                 return
 


### PR DESCRIPTION
`2to3` was runned on all three scripts, with no additional modifications made.

A couple of Python 2 libraries have been switched to their Python 3 counterparts (`tkinter`, `_thread`, `httplib` and `urllib`), which should not affect the functionality of the scripts. That said, I'm not familiar with any of these modules.

I've tested both the CLI and GUI tools on Windows 10, Python 3.9, and had no issues with them other than this Exception in the CLI tool:

```bash
PS C:\Users\weien\Workspace\nus-exams-downloader> python .\examdownloader-cli.py
Enter NUSNET ID: [hidden]
Enter password for [hidden]:
Enter module to download exams for: CS2030
Connecting to NUS Library Portals...
Downloading 1 of 7
Writing 1718SEM1-S2030.pdf
Downloading 2 of 7
Writing 1718SEM2-CS2030.pdf
Downloading 3 of 7
Writing 1718-ST-CS2030.pdf
Downloading 4 of 7
Writing 1819SEM1-CS2030.pdf
Downloading 5 of 7
Writing 1819SEM2-CS2030(Sec B).PDF
Downloading 6 of 7
Writing 1920SEM2-CS2030.pdf
Downloading 7 of 7
Writing 1930SEM1-CS2030 (Special Sem 1).pdf
7 papers downloaded successfully!
Traceback (most recent call last):
  File "C:\Users\weien\Workspace\nus-exams-downloader\examdownloader-cli.py", line 56, in <module>
    startDownload(module, username, destination, password)
  File "C:\Users\weien\Workspace\nus-exams-downloader\examdownloader-cli.py", line 25, in startDownload
    ed.getContents(module, username, password, destination, downloadCallback, updateStatus)
  File "C:\Users\weien\Workspace\nus-exams-downloader\examdownloader.py", line 123, in getContents
    downloadEndCallback(True, filename, counter)
  File "C:\Users\weien\Workspace\nus-exams-downloader\examdownloader-cli.py", line 21, in downloadCallback
    subprocess.call(['open', '-R', lastfile])
  File "C:\Python39\lib\subprocess.py", line 349, in call
    with Popen(*popenargs, **kwargs) as p:
  File "C:\Python39\lib\subprocess.py", line 947, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Python39\lib\subprocess.py", line 1416, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

Unfortunately I don't have the time to look into this issue right now, but I believe this can be replicated on the original Python 2 scripts, so it's probably not caused by the migration.